### PR TITLE
Separate between unit and integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
-
 # the main binary
 cmd/dex-operator/dex-operator
+
+# code coverage
+cover.out
 
 # images
 *dex-operator-latest.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,11 @@ check:
 
 .PHONY: test
 test:
-	@$(GO) test -v $(SOURCE_DIRS_GO) -coverprofile cover.out
+	@$(GO) test -short -v $(SOURCES_DIRS_GO) -coverprofile cover.out
+
+.PHONY: integration
+integration:
+	@$(GO) test -v $(SOURCES_DIRS_GO) -coverprofile cover.out
 
 .PHONY: check
 clean: docker-image-clean

--- a/pkg/apis/kubic/v1beta1/dexconfiguration_types_test.go
+++ b/pkg/apis/kubic/v1beta1/dexconfiguration_types_test.go
@@ -24,9 +24,13 @@ import (
 	"golang.org/x/net/context"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/kubic-project/dex-operator/pkg/test"
 )
 
 func TestStorageDexConfiguration(t *testing.T) {
+	test.SkipIfNotIntegrationTesting(t)
+
 	key := types.NamespacedName{
 		Name: "foo",
 	}

--- a/pkg/apis/kubic/v1beta1/ldapconnector_types_test.go
+++ b/pkg/apis/kubic/v1beta1/ldapconnector_types_test.go
@@ -24,9 +24,13 @@ import (
 	"golang.org/x/net/context"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/kubic-project/dex-operator/pkg/test"
 )
 
 func TestStorageLDAPConnector(t *testing.T) {
+	test.SkipIfNotIntegrationTesting(t)
+
 	key := types.NamespacedName{
 		Name: "foo",
 	}

--- a/pkg/apis/kubic/v1beta1/v1beta1_suite_test.go
+++ b/pkg/apis/kubic/v1beta1/v1beta1_suite_test.go
@@ -33,6 +33,10 @@ var cfg *rest.Config
 var c client.Client
 
 func TestMain(m *testing.M) {
+	if testing.Short() {
+		return
+	}
+
 	t := &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "..", "configs", "crds")},
 	}

--- a/pkg/controller/dex/dexconfiguration_controller_suite_test.go
+++ b/pkg/controller/dex/dexconfiguration_controller_suite_test.go
@@ -35,6 +35,10 @@ import (
 var cfg *rest.Config
 
 func TestMain(m *testing.M) {
+	if testing.Short() {
+		return
+	}
+
 	t := &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crds")},
 	}

--- a/pkg/controller/dex/dexconfiguration_controller_test.go
+++ b/pkg/controller/dex/dexconfiguration_controller_test.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kubicv1beta1 "github.com/kubic-project/dex-operator/pkg/apis/kubic/v1beta1"
-	"github.com/kubic-project/dex-operator/pkg/config"
+	"github.com/kubic-project/dex-operator/pkg/test"
 )
 
 var c client.Client
@@ -43,6 +43,8 @@ var depKey = types.NamespacedName{Name: "foo-deployment", Namespace: "default"}
 const timeout = time.Second * 5
 
 func TestReconcile(t *testing.T) {
+	test.SkipIfNotIntegrationTesting(t)
+
 	g := gomega.NewGomegaWithT(t)
 	instance := &kubicv1beta1.DexConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 
@@ -52,9 +54,7 @@ func TestReconcile(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 
-	kubicCfg := config.KubicInitConfiguration{}
-
-	recFn, requests := SetupTestReconcile(newReconciler(mgr, &kubicCfg))
+	recFn, requests := SetupTestReconcile(newReconciler(mgr))
 	g.Expect(add(mgr, recFn)).NotTo(gomega.HaveOccurred())
 	defer close(StartTestManager(mgr, g))
 

--- a/pkg/test/util.go
+++ b/pkg/test/util.go
@@ -15,22 +15,16 @@
  *
  */
 
-package crypto
+package test
 
 import (
 	"testing"
 )
 
-func TestNewSharedPassword(t *testing.T) {
-	password1 := NewSharedPassword("my-password1", "my-namespace")
-	password1.Rand(10)
-	if password1.Name != "my-namespace/my-password1" {
-		t.Fatalf("Unexpected password name: %s", password1.Name)
-	}
-
-	password2 := NewSharedPassword("my-password2", "")
-	password2.Rand(10)
-	if password2.Name != "kube-system/my-password2" {
-		t.Fatalf("Unexpected password name: %s", password2.Name)
+// SkipIfNotIntegrationTesting should skip this specific test if we are not running in integration
+// testing mode
+func SkipIfNotIntegrationTesting(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
 	}
 }


### PR DESCRIPTION
Also, fix some issues that existed with the tests themselves. For unit
tests now we have the Makefile target `test`, and for integration tests
`integration`.