### PR TITLE
updated makefile to report lint errors as errors for ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ golint:
 
 .PHONY: check
 check: fmt golint
-	@for d in $$($(GO) list ./... | grep -v /vendor/); do golint $${d}; done
+	@for d in $$($(GO) list ./... | grep -v /vendor/); do golint -set_exit_status $${d}; done
 	@$(GO) tool vet ${DEX_OPER_SRCS}
 
 .PHONY: test


### PR DESCRIPTION
## What does this PR change?
golint errors should now be errors in CI.

## Documentation
golint errors should now report as errors.


## Test coverage
updated golint to report findings as errors.

## Links

(add here link to GitHub Issues)
Fixes # kubic-project/dex-operator/#13